### PR TITLE
一些细节上的修改，并添加了一个不使用对话框的版本

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Auto editing loudness by vibrato (notes properties &amp; vibrato env.) Currently
 
 Select notes which u want this script to process, and click `Scripts -> tool -> auto loudness by vibrato`, then set appropriate parameters, click `Ok`.
 
+## Kown Issues
+
+Custom dialogues in Synth V editor 1.7.0 may crash. If that happens, use the one without custom dialogue instead.
+
+
 # SynthV 根据颤音自动画响度 插件
 
 根据颤音（音符属性&颤音包络）自动画响度曲线，暂时只有`覆盖原响度`和`叠加在原响度上`的模式。可以自行设置合适的强度和曲线精度（每四分音符 参数点的数量），也可以选择是否简化响度曲线。
@@ -14,6 +19,6 @@ Select notes which u want this script to process, and click `Scripts -> tool -> 
 
 选取（可多选）你想让本插件处理的音符，点击`脚本 -> tool -> 根据颤音设置响度`，设置合适的参数，然后执行。
 
-## 注意
+## 已知问题
 
-不支持在音符内部有bpm改变的情况
+1.7.0版本的SynthV编辑器存在javascript对话框可能崩溃的问题。若遇到此问题，可使用无对话框的版本。

--- a/auto_loudness_by_vibrato_no_dialogue.js
+++ b/auto_loudness_by_vibrato_no_dialogue.js
@@ -1,5 +1,16 @@
-var SCRIPT_TITLE = "auto loudness by vibrato";
+var SCRIPT_TITLE = "auto loudness by vibrato without dialogue";
 var debug_count = 0;
+
+
+// Modify parameters here and then reload scripts
+var option = {
+    "density": 20,      //points per quarter. recommended value: [4, 256]
+    "strength": 2,      //variation strength of loudness. recommended value: [0, 6]
+    "mode": 0,          //add: 0, overwrite: 1
+    "simp": true        //simplify control points
+};
+
+
 
 function getClientInfo() {
     return {
@@ -14,7 +25,7 @@ function getTranslations(langCode) {
     if (langCode == "zh-cn") {
         return [
             // getClientInfo()
-            ["auto loudness by vibrato", "根据颤音设置响度"],
+            ["auto loudness by vibrato without dialogue", "根据颤音设置响度（无对话框）"],
 
             // warning_save()
             ["auto loudness by vibrato: WARNING", "根据颤音设置响度：警告"],
@@ -158,63 +169,16 @@ function modify_loudness(option) {
 function main() {
     if (warning_save() == false) { SV.finish(); return; };
     // custom dialog
-    var form = {
-        title: SV.T(SCRIPT_TITLE),
-        message: "",
-        buttons: "OkCancel",
-        widgets: [
-            {
-                "name": "strength",
-                "type": "Slider",
-                "label": SV.T("Strength(dB)"),
-                "format": "%1.2f",
-                "minValue": 0,
-                "maxValue": 6,
-                "interval": 0.05,
-                "default": 1
-            },
-            {
-                "name": "density",
-                "type": "Slider",
-                "label": SV.T("Points per quarter"),
-                "format": "%3.0f",
-                "minValue": 4,
-                "maxValue": 256,
-                "interval": 1,
-                "default": 32
-            },
-            {
-                "name": "mode", "type": "ComboBox",
-                "label": SV.T("mode"),
-                "choices": [SV.T("add"), SV.T("overwrite")],
-                "default": 0
-            },
-            {
-                "name": "simp", "type": "CheckBox",
-                "text": SV.T("simplify the curve"),
-                "default": true
-            }
-        ]
-    };
 
-    var result = SV.showCustomDialog(form);
-    if (result.status) {
-        var option = {
-            "density": result.answers.density,
-            "strength": result.answers.strength,
-            "mode": result.answers.mode,
-            "simp": result.answers.simp
-        };
-        var r = modify_loudness(option);
-        if (r.flagOverPeakWarning) {
-            SV.showMessageBox(SCRIPT_TITLE + "    ",
-                SV.T("There is some point that over 12dB which involves in something like 'Clipping distortion' in parameter panel.") + "\n"
-                + r.num_processed.toString() + SV.T(" notes edited."));
-        }
-        else {
-            SV.showMessageBox(SCRIPT_TITLE + "    ", r.num_processed.toString() + SV.T(" notes edited."));
-        }
-
+    var r = modify_loudness(option);
+    if (r.flagOverPeakWarning) {
+        SV.showMessageBox(SCRIPT_TITLE + "    ",
+            SV.T("There is some point that over 12dB which involves in something like 'Clipping distortion' in parameter panel.") + "\n"
+            + r.num_processed.toString() + SV.T(" notes edited."));
     }
+    else {
+        SV.showMessageBox(SCRIPT_TITLE + "    ", r.num_processed.toString() + SV.T(" notes edited."));
+    }
+
     SV.finish();
 }


### PR DESCRIPTION
即使选择了叠加模式，原先的控制点也应该全部抹去，否则原先的控制点会与绘制的控制点同时存在
1.7.0版本的SV编辑器有JS脚本对话框崩溃的问题，因此我添加了一个不使用对话框的版本